### PR TITLE
add support for query filtering

### DIFF
--- a/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
+++ b/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * @param <T>
  * @author klau
  */
-public class PaginatedGrid<T> extends Grid<T> {
+public class PaginatedGrid<T, F> extends Grid<T> {
 
     private final LitPagination pagination = new LitPagination();
 
@@ -31,7 +31,8 @@ public class PaginatedGrid<T> extends Grid<T> {
 
     private DataProvider<T, ?> dataProvider;
 
-
+    private F filter;
+    
     public PaginatedGrid() {
         super();
         init();
@@ -178,6 +179,10 @@ public class PaginatedGrid<T> extends Grid<T> {
         }
 
     }
+    
+    public void setFilter(F filter) {
+    	this.filter = filter;
+    } 
 
     /**
      * change visibility of pagination component
@@ -209,9 +214,17 @@ public class PaginatedGrid<T> extends Grid<T> {
         InnerQuery() {
             this(0);
         }
+        
+        InnerQuery(F filter) {
+            this(0, filter);
+        }
 
         InnerQuery(int offset) {
             super(offset, getPageSize(), getDataCommunicator().getBackEndSorting(), getDataCommunicator().getInMemorySorting(), null);
+        }
+
+        InnerQuery(int offset, F filter) {
+            super(offset, getPageSize(), getDataCommunicator().getBackEndSorting(), getDataCommunicator().getInMemorySorting(), filter);
         }
 
         InnerQuery(int offset, List<QuerySortOrder> sortOrders, SerializableComparator<T> serializableComparator) {

--- a/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
+++ b/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
@@ -88,7 +88,7 @@ public class PaginatedGrid<T, F> extends Grid<T> {
     private void doCalcs(int newPage) {
         int offset = newPage > 0 ? (newPage - 1) * this.getPageSize() : 0;
 
-        InnerQuery query = new InnerQuery<>(offset);
+        InnerQuery query = new InnerQuery<>(offset, filter);
 
         pagination.setTotal(dataProvider.size(query));
 


### PR DESCRIPTION
hey,
thanks for the time and effort invested in this component.

we would need the ability to send some filtering fields to the dataProvider through the InnerQuery.

the api would look like this:

```
@Data
public static class CustomFilter {
    private String name;
}

[...]

PaginatedGrid<Person, CustomFilter> grid = new PaginatedGrid<>();
grid.setDataProvider(personService);
grid.setFilter(filter);

```

and, on the dataProvider:

```
PersonService extends AbstractBackEndDataProvider<Person, CustomFilter> {

[...]

    @Override
    protected Stream<BonusWalletDefinition> fetchFromBackEnd(Query<BonusWalletDefinition, CustomFilter> query) {
	CustomFilter filter = query.getFilter().orElseThrow();
        return findByName( filter.getName() );
    }

}
```

do you have something similar or do you think something like this can be added?
I would really need this.

Thank you,
Emanuel