### PR TITLE
Upgraded to Vaadin 23.2.4 as it uses newer Lit version. With the olde…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Grid Pagination
 
-This addon adds pagination feature to the Vaadin 14+ Grid component. To do so, it extends the existing Vaadin 14 Grid and creates a custom PaginatedGrid
+This addon adds pagination feature to the Vaadin 23.2.4+ Grid component. To do so, it extends the existing Vaadin 23 Grid and creates a custom PaginatedGrid
 
 An internal LitPagination component is created which handles the pagination and navigation through pages. 
 
 ## Usage instructions
 
-To use the pagination feature on the grid you just have to use PaginatedGrid component instead of the standard Vaadin 14+ Grid as follows: 
+To use the pagination feature on the grid you just have to use PaginatedGrid component instead of the standard Vaadin 23.2.4+ Grid as follows: 
 
 ```
 	PaginatedGrid<Address> grid = new PaginatedGrid<>();

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,15 @@
 
     <groupId>org.vaadin.klaudeta</groupId>
     <artifactId>grid-pagination</artifactId>
-    <version>2.0.10</version>
+    <version>3.0.0</version>
     <name>Grid Pagination</name>
-    <description>Integration of lit-pagination for Vaadin 14.x</description>
+    <description>Integration of lit-pagination for Vaadin 23.2.4+</description>
 
     <properties>
-        <vaadin.version>14.4.2</vaadin.version>
+        <vaadin.version>23.2.4</vaadin.version>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/src/main/java/org/vaadin/klaudeta/LitPagination.java
+++ b/src/main/java/org/vaadin/klaudeta/LitPagination.java
@@ -20,8 +20,8 @@ import com.vaadin.flow.shared.Registration;
 @NpmPackage(value = "@polymer/paper-button", version = "^3.0.1")
 @NpmPackage(value = "@polymer/iron-iconset-svg", version = "^3.0.1")
 @NpmPackage(value = "@polymer/paper-icon-button", version = "^3.0.2")
-@NpmPackage(value = "lit-element", version = "^2.2.1")
-@NpmPackage(value = "lit-html", version = "^1.1.2")
+@NpmPackage(value = "lit-element", version = "^3.2.2")
+@NpmPackage(value = "lit-html", version = "2.4.0")
 @JsModule("./lit-pagination.js")
 public class LitPagination extends Component implements LitPaginationModel{
 

--- a/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
+++ b/src/main/java/org/vaadin/klaudeta/PaginatedGrid.java
@@ -211,11 +211,11 @@ public class PaginatedGrid<T> extends Grid<T> {
         }
 
         InnerQuery(int offset) {
-            super(offset, getPageSize(), getDataCommunicator().getBackEndSorting(), getDataCommunicator().getInMemorySorting(), null);
+            super(offset, pagination.getPageSize(), getDataCommunicator().getBackEndSorting(), getDataCommunicator().getInMemorySorting(), null);
         }
 
         InnerQuery(int offset, List<QuerySortOrder> sortOrders, SerializableComparator<T> serializableComparator) {
-            super(offset, getPageSize(), sortOrders, serializableComparator, null);
+            super(offset, pagination.getPageSize(), sortOrders, serializableComparator, null);
         }
 
     }


### PR DESCRIPTION
…r Lit version, Vaadin 23.2.4 projects using grid-pagination throws Vite errors and cannot be compiled.